### PR TITLE
Fix uninitialized constant RAILS_DEFAULT_LOGGER

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'redmine'
 
-RAILS_DEFAULT_LOGGER.info 'Starting wiki_latex_plugin for Redmine'
+Rails.logger.info 'Starting wiki_latex_plugin for Redmine'
 
 Redmine::Plugin.register :wiki_latex_plugin do
   name 'Latex Wiki-macro Plugin'


### PR DESCRIPTION
RAILS_DEFAULT_LOGGER.info Call has been deprecated in favor of Rails.logger.info
